### PR TITLE
Add tooltips over the different statistics on the right of the experiment display

### DIFF
--- a/frontend/components/ExperimentDisplay.vue
+++ b/frontend/components/ExperimentDisplay.vue
@@ -105,6 +105,7 @@
           :key="kpi.description"
           :value="kpi.value"
           :description="kpi.description"
+          :tooltip="kpi.tooltip"
           class="mx-auto"
         ></KPIBox>
       </b-col>
@@ -234,38 +235,50 @@ export default {
         return [
           {
             description: 'Optimized accelerator',
-            value: this.experiment.accelerator
+            value: this.experiment.accelerator,
+            tooltip: 'The name of the optimized component'
           },
           {
             description: 'Gain compared to default',
             value:
-              parseFloat(this.experiment.improvement_default).toFixed(2) + '%'
+              parseFloat(this.experiment.improvement_default).toFixed(2) + '%',
+            tooltip:
+              'Time gain compared to the default parametrization, expressed in percentage.'
           },
           {
             description: 'Average noise',
-            value: parseFloat(this.experiment.average_noise).toFixed(3)
+            value: parseFloat(this.experiment.average_noise).toFixed(3),
+            tooltip: 'Standard error within each tested parametrization'
           },
           {
             description: '% of explored space',
-            value: parseFloat(this.experiment.explored_space).toFixed(3)
+            value: parseFloat(this.experiment.explored_space).toFixed(3),
+            tooltip:
+              'Ratio of different tested parametrization compared to the total of possible parametrizations'
           }
         ]
       } else {
         return [
           {
-            description: 'Optimized accelerator',
-            value: ''
+            description: 'Optimized component',
+            value: '',
+            tooltip: 'The name of the optimized component'
           },
           {
             description: 'Gain compared to default',
+            tooltip:
+              'Time gain compared to the default parametrization, expressed in percentage.',
             value: 0
           },
           {
             description: 'Average noise',
-            value: 0
+            value: 0,
+            tooltip: 'Standard error within each tested parametrization'
           },
           {
             description: '% of explored space',
+            tooltip:
+              'Ratio of different tested parametrization compared to the total of possible parametrizations',
             value: 0
           }
         ]
@@ -370,14 +383,10 @@ export default {
   },
   mounted() {
     axios
-      .all([
-        axios.get('/experiments/' + this.objectid)
-        // axios.get('/io_durations/' + this.objectid)
-      ])
+      .all([axios.get('/experiments/' + this.objectid)])
       .then(
         axios.spread((experimentResponse, ioDurationResponse) => {
           this.experiment = experimentResponse.data
-          //          this.ioDurations = ioDurationResponse.data
         })
       )
       .catch((e) => console.log(e))
@@ -396,3 +405,113 @@ export default {
   }
 }
 </script>
+
+<style>
+/* Tooltip style: taken from https://github.com/Akryum/v-tooltip#style-examples*/
+.tooltip {
+  display: block !important;
+  z-index: 10000;
+}
+
+.tooltip .tooltip-inner {
+  background: #d53f8c;
+  color: white;
+  border-radius: 16px;
+  padding: 5px 10px 4px;
+  font-size: 1rem;
+}
+
+.tooltip .tooltip-arrow {
+  width: 0;
+  height: 0;
+  border-style: solid;
+  position: absolute;
+  margin: 5px;
+  border-color: #d53f8c;
+  z-index: 1;
+}
+
+.tooltip[x-placement^='top'] {
+  margin-bottom: 5px;
+}
+
+.tooltip[x-placement^='top'] .tooltip-arrow {
+  border-width: 5px 5px 0 5px;
+  border-left-color: transparent !important;
+  border-right-color: transparent !important;
+  border-bottom-color: transparent !important;
+  bottom: -5px;
+  left: calc(50% - 5px);
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.tooltip[x-placement^='bottom'] {
+  margin-top: 5px;
+}
+
+.tooltip[x-placement^='bottom'] .tooltip-arrow {
+  border-width: 0 5px 5px 5px;
+  border-left-color: transparent !important;
+  border-right-color: transparent !important;
+  border-top-color: transparent !important;
+  top: -5px;
+  left: calc(50% - 5px);
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.tooltip[x-placement^='right'] {
+  margin-left: 5px;
+}
+
+.tooltip[x-placement^='right'] .tooltip-arrow {
+  border-width: 5px 5px 5px 0;
+  border-left-color: transparent !important;
+  border-top-color: transparent !important;
+  border-bottom-color: transparent !important;
+  left: -5px;
+  top: calc(50% - 5px);
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.tooltip[x-placement^='left'] {
+  margin-right: 5px;
+}
+
+.tooltip[x-placement^='left'] .tooltip-arrow {
+  border-width: 5px 0 5px 5px;
+  border-top-color: transparent !important;
+  border-right-color: transparent !important;
+  border-bottom-color: transparent !important;
+  right: -5px;
+  top: calc(50% - 5px);
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.tooltip.popover .popover-inner {
+  background: #f9f9f9;
+  color: black;
+  padding: 24px;
+  border-radius: 5px;
+  box-shadow: 0 5px 30px rgba(black, 0.1);
+}
+
+.tooltip.popover .popover-arrow {
+  border-color: #f9f9f9;
+}
+
+.tooltip[aria-hidden='true'] {
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.15s, visibility 0.15s;
+}
+
+.tooltip[aria-hidden='false'] {
+  visibility: visible;
+  opacity: 1;
+  transition: opacity 0.15s;
+}
+</style>

--- a/frontend/components/KPIBox.vue
+++ b/frontend/components/KPIBox.vue
@@ -3,6 +3,7 @@
  -->
   <b-col>
     <div
+      v-tooltip.right="tooltip"
       class="kpi shadow-xl rounded-md px-3 py-3 mt-4 bg-pink-100 border-2 border-pink-700"
     >
       <div class="text-2xl font-bold tracking-widest pt-2 pb-1">
@@ -23,6 +24,10 @@ export default {
       default: '0'
     },
     description: {
+      type: String,
+      default: ''
+    },
+    tooltip: {
       type: String,
       default: ''
     }

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -52,6 +52,7 @@ export default {
     { src: '@/plugins/aos', ssr: false },
     { src: '@/plugins/mocks', ssr: false },
     { src: '@/plugins/axios' },
+    { src: '@/plugins/v-tooltip', ssr:false },
     { src: '~plugins/vue-apexcharts', ssr: false },
     { src: '~plugins/highlight', ssr: false },
     { src: '~plugins/nuxt-codemirror.js', ssr: false }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14768,6 +14768,16 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
+    "v-tooltip": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/v-tooltip/-/v-tooltip-2.0.3.tgz",
+      "integrity": "sha512-KZZY3s+dcijzZmV2qoDH4rYmjMZ9YKGBVoUznZKQX0e3c2GjpJm3Sldzz8HHH2Ud87JqhZPB4+4gyKZ6m98cKQ==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "popper.js": "^1.16.0",
+        "vue-resize": "^0.4.5"
+      }
+    },
     "v8-compile-cache": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
@@ -14936,6 +14946,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/vue-no-ssr/-/vue-no-ssr-1.1.1.tgz",
       "integrity": "sha512-ZMjqRpWabMPqPc7gIrG0Nw6vRf1+itwf0Itft7LbMXs2g3Zs/NFmevjZGN1x7K3Q95GmIjWbQZTVerxiBxI+0g=="
+    },
+    "vue-resize": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-0.4.5.tgz",
+      "integrity": "sha512-bhP7MlgJQ8TIkZJXAfDf78uJO+mEI3CaLABLjv0WNzr4CcGRGPIAItyWYnP6LsPA4Oq0WE+suidNs6dgpO4RHg=="
     },
     "vue-router": {
       "version": "3.4.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "hammerjs": "^2.0.8",
     "highlight.js": "^10.1.1",
     "nuxt": "^2.14.4",
+    "v-tooltip": "^2.0.3",
     "vue-apexcharts": "^1.5.3",
     "vue-chartjs": "^3.5.0",
     "vue-codemirror": "^4.0.6",

--- a/frontend/plugins/v-tooltip.js
+++ b/frontend/plugins/v-tooltip.js
@@ -1,0 +1,6 @@
+import Vue from 'vue'
+import { VTooltip, VPopover, VClosePopover } from 'v-tooltip'
+
+Vue.directive('tooltip', VTooltip)
+Vue.directive('close-popover', VClosePopover)
+Vue.component('v-popover', VPopover)


### PR DESCRIPTION
Added tooltips on the side of the experiment display page, relying on the v-tooltip npm library. Might be a bit too pink.

Fixes #22 