### PR TITLE
Handle parameters as list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ cma = { optional = true, version = "^3.0.3" }
 scipy = { optional = true, version = "^1.5.2" }
 pandas = { optional = true, version = "^1.1.2" }
 loguru = "^0.5.3"
-pip = "^20.2.4"
+pip = "^21.0.0"
 install = "^1.3.4"
 
 [tool.poetry.dev-dependencies]
@@ -52,9 +52,16 @@ mknotebooks = "^0.6.2"
 [tool.poetry.extras]
 bb-wrapper = ["pydantic", "requests", "typer", "PyYAML"]
 bbo = ["numpy", "scikit-learn", "cma", "scipy", "pandas"]
-shaman-api = ["fastapi", "uvicorn", "arq", "motor", "starlette-exporter", "typer"]
+shaman-api = [
+    "fastapi",
+    "uvicorn",
+    "arq",
+    "motor",
+    "starlette-exporter",
+    "typer",
+]
 shaman-worker = ["arq", "prometheus-client", "httpx", "pydantic"]
-shaman-core = ["pydantic","httpx","pyyaml"]
+shaman-core = ["pydantic", "httpx", "pyyaml"]
 
 [tool.poetry.scripts]
 shaman-api = "shaman_api.cli:cli"
@@ -67,4 +74,3 @@ line-length = 79
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
-

--- a/shaman_project/shaman_core/models/shaman_config_model.py
+++ b/shaman_project/shaman_core/models/shaman_config_model.py
@@ -120,7 +120,8 @@ class SHAManConfig(BaseConfiguration):
     pruning: Optional[PruningParameters] = None
     noise_reduction: Optional[Dict] = None
     component_parameters: Dict[str,
-                               Union[ParameterRange, List]] = dataclasses.field(init=False)
+                               Union[ParameterRange, List]] = \
+        dataclasses.field(init=False)
 
     def __post_init__(self) -> None:
         """Initialize an object of class SHAManConfig."""

--- a/shaman_project/shaman_core/models/shaman_config_model.py
+++ b/shaman_project/shaman_core/models/shaman_config_model.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from pydantic import BaseModel, validator, root_validator
 from pydantic.dataclasses import dataclass
 
-from typing import Dict, Optional, List, Any
+from typing import Dict, Optional, List, Any, Union
 from enum import Enum
 import importlib
 import ast
@@ -105,18 +105,22 @@ class ParameterRange(BaseModel):
             return np.array(range_)
 
 
+class ParameterList(BaseModel):
+    """Contains the possible values of the parameters when"""
+
+
 @dataclass
 class SHAManConfig(BaseConfiguration):
     """Contains the configuration of the SHAMan application."""
 
     experiment: ExperimentParameters
     bbo: Dict
-    components: Dict[str, Dict[str, ParameterRange]]
+    components: Dict[str, Dict[str, Union[ParameterRange, List]]]
     component_name: str
     pruning: Optional[PruningParameters] = None
     noise_reduction: Optional[Dict] = None
     component_parameters: Dict[str,
-                               ParameterRange] = dataclasses.field(init=False)
+                               Union[ParameterRange, List]] = dataclasses.field(init=False)
 
     def __post_init__(self) -> None:
         """Initialize an object of class SHAManConfig."""
@@ -156,9 +160,17 @@ class SHAManConfig(BaseConfiguration):
 
     @property
     def component_parameter_space(self) -> np.ndarray:
-        """Returns the range of the parameters."""
+        """Returns the range of the parameters, and takes into account
+        whether the specified component range is a list or a parameter
+        range."""
         array_parameters = list()
         for parameter_range in self.component_parameters.values():
-            array_parameters.append(np.array(parameter_range.parameter_range))
+            # Check if the parameter_range has been specified as a
+            # ParameterRange (min, max step)
+            if isinstance(parameter_range, ParameterRange):
+                array_parameters.append(
+                    np.array(parameter_range.parameter_range))
+            else:
+                array_parameters.append(np.sort(np.array(parameter_range)))
         logger.debug(f"Parameter space: {array_parameters}")
         return np.array(array_parameters, dtype=object)

--- a/tests/shaman_core/unit/test_shaman_config/vanilla.yaml
+++ b/tests/shaman_core/unit/test_shaman_config/vanilla.yaml
@@ -22,6 +22,10 @@ components:
       max: 8
       step: 2
       step_type: multiplicative
+    param_3:
+      - 1
+      - 4
+      - 12
 
   component_2:
     param_1:

--- a/tests/shaman_core/unit/test_shaman_config_model.py
+++ b/tests/shaman_core/unit/test_shaman_config_model.py
@@ -50,7 +50,8 @@ class TestSHAManModelVanilla(unittest.TestCase):
         """Tests that loading the config from yaml behaves as expected for component_1."""
         shaman_config = SHAManConfig.from_yaml(VANILLA_CONFIG, "component_1")
         self.assertEqual(
-            shaman_config.component_parameter_names, ["param_1", "param_2"]
+            shaman_config.component_parameter_names, [
+                "param_1", "param_2", "param_3"]
         )
 
     def test_load_config_vanilla_component_2(self):
@@ -78,13 +79,18 @@ class TestSHAManModelVanilla(unittest.TestCase):
         and additive"""
         shaman_config = SHAManConfig.from_yaml(VANILLA_CONFIG, "component_1")
         expected_parameter_space = numpy.array(
-            [numpy.array([1, 2]), numpy.array([2, 4, 8])], dtype=object
+            [numpy.array([1, 2]), numpy.array(
+                [2, 4, 8]), numpy.array([1, 4, 12])],
+            dtype=object
         )
         assert_array_equal(
             expected_parameter_space[0], shaman_config.component_parameter_space[0]
         )
         assert_array_equal(
             expected_parameter_space[1], shaman_config.component_parameter_space[1]
+        )
+        assert_array_equal(
+            expected_parameter_space[2], shaman_config.component_parameter_space[2]
         )
 
     def test_bbo_init(self):
@@ -109,7 +115,8 @@ class TestSHAManModelVanilla(unittest.TestCase):
     def test_wrong_parameter_space(self):
         """Tests that when the parametric space makes no sense, an error is raised."""
         with self.assertRaises(ValueError):
-            shaman_config = SHAManConfig.from_yaml(VANILLA_CONFIG_WRONG, "component_1")
+            shaman_config = SHAManConfig.from_yaml(
+                VANILLA_CONFIG_WRONG, "component_1")
 
 
 class TestSHAManNoiseReduction(unittest.TestCase):
@@ -120,7 +127,8 @@ class TestSHAManNoiseReduction(unittest.TestCase):
     def test_noise_reduction(self):
         """Tests that the noise reduction parameters are properly parsed.
         """
-        shaman_config = SHAManConfig.from_yaml(NOISE_REDUCTION_CONFIG, "component_1")
+        shaman_config = SHAManConfig.from_yaml(
+            NOISE_REDUCTION_CONFIG, "component_1")
         expected_noise_reduction_parameters = {
             "resampling_policy": "simple_resampling",
             "estimator": "numpy.median",
@@ -135,13 +143,15 @@ class TestSHAManNoiseReduction(unittest.TestCase):
         """Tests that the noise reduction parameters are properly added to the bbo_kwargs and
         the BBOptimizer object can be initialized.
         """
-        shaman_config = SHAManConfig.from_yaml(NOISE_REDUCTION_CONFIG, "component_1")
+        shaman_config = SHAManConfig.from_yaml(
+            NOISE_REDUCTION_CONFIG, "component_1")
         # Check that the dictionary has been properly updated
         assert "nbr_resamples" in shaman_config.bbo_parameters
         assert "fitness_aggregation" in shaman_config.bbo_parameters
         assert "resampling_policy" in shaman_config.bbo_parameters
         # Check that the estimator function is properly parsed
-        self.assertEqual(shaman_config.bbo_parameters["estimator"], numpy.median)
+        self.assertEqual(
+            shaman_config.bbo_parameters["estimator"], numpy.median)
         # Check that the BBOptimizer class can be properly instanciated
         BBOptimizer(
             black_box=FakeBlackBox,
@@ -171,7 +181,8 @@ class TestSHAManPruning(unittest.TestCase):
     def test_pruning_parameters_function(self):
         """Tests that the pruning parameters are properly parsed when max_step_duration is a function.
         """
-        pruning_parameters = PruningParameters(max_step_duration="numpy.median")
+        pruning_parameters = PruningParameters(
+            max_step_duration="numpy.median")
         self.assertEqual(pruning_parameters.max_step_duration, numpy.median)
 
     def test_pruning_parameters_wrong_type(self):


### PR DESCRIPTION
SHAMan is now able to handle parameters as a list of integers or float. This feature is not yet implemented in the UI version.

An example of syntax in a configuration file for experiment submission:
``yaml
components:
  component_1:
    param_1:
      min: 1
      max: 2
      step: 1
    param_2:
      min: 2
      max: 8
      step: 2
      step_type: multiplicative
    param_3:
      - 1
      - 4
      - 12
`` 